### PR TITLE
Disable wiki for all repositories but velocitas-docs

### DIFF
--- a/.github/workflows/build-page.yml
+++ b/.github/workflows/build-page.yml
@@ -1,0 +1,113 @@
+name: Build GH Page
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'otterdog/*.jsonnet'
+      - 'otterdog/*.json'
+      - 'docs/*'
+      - 'mkdocs.yml'
+      - '.github/workflows/build-page.yml'
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  generate-markdown:
+    # do not run the workflow in the template repo itself
+    if: ${{ !contains (github.repository, '/.eclipsefdn-template') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout OtterDog
+        run: git clone https://gitlab.eclipse.org/eclipsefdn/security/otterdog.git
+
+      - name: Checkout EclipseFdn/otterdog-configs
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          repository: EclipseFdn/otterdog-configs
+          path: otterdog-configs
+
+      # checkout the HEAD ref
+      - name: Checkout HEAD
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          path: ${{ github.repository_owner }}
+
+      - name: Install jsonnet-bundler
+        run: |
+          go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.5.1
+          echo $(go env GOPATH)/bin >> $GITHUB_PATH
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Setup Python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
+        with:
+          python-version: '3.10'
+          cache: 'poetry'
+
+      - name: Install dependencies with poetry
+        run: |
+          poetry install --only=main
+        working-directory: otterdog
+
+      - name: Copy configuration from HEAD ref
+        run: |
+          mkdir -p orgs/${{ github.repository_owner }}
+          cp -r ../${{ github.repository_owner }}/otterdog/* orgs/${{ github.repository_owner }}
+        working-directory: otterdog-configs
+
+      - name: Generate default configuration as markdown
+        run: ../otterdog/otterdog.sh show-default ${{ github.repository_owner }} -c otterdog.json --markdown > default.txt
+        working-directory: otterdog-configs
+
+      - name: Upload default text snippet
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        with:
+          name: default-text
+          path: otterdog-configs/default.txt
+
+  build-page:
+    runs-on: ubuntu-latest
+    needs: generate-markdown
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: Download default-text
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+        with:
+          name: default-text
+      - shell: bash
+        run: |
+          cat default.txt >> ./docs/index.md
+      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
+        with:
+          python-version: 3.x
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+      - name: Build with Mkdocs
+        run: mkdocs build
+      - name: Setup Pages
+        uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382 # v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@84bb4cd4b733d5c320c9c9cfbc354937524f4d64 # v1
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-page
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@12ab2b16cf43a7a061fe99da74b6f8f11fb77f5b # pin@v2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# .eclipsefdn
+# Eclipse Foundation Config Repo
 
 Repository to host configurations related to the Eclipse Foundation.
 
-## Self service of GitHub organizations
+## Self service of your GitHub organization
 
-Please find more information at <https://eclipse-velocitas.github.io/.eclipsefdn/>.
+You can find more information at <https://eclipse-velocitas.github.io/.eclipsefdn/>.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Repository to host configurations related to the Eclipse Foundation.
 
 ## Self service of GitHub organizations
 
-Documentation for using the self-service (stored in directory *otterdog*) can be accessed at [otterdog.readthedocs.io](https://otterdog.readthedocs.io).
+Please find more information at <https://eclipse-velocitas.github.io/.eclipsefdn/>.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+# Self-service of GitHub resources
+
+General documentation for using the self-service (stored in directory *otterdog*) can be accessed at [otterdog.readthedocs.io](https://otterdog.readthedocs.io).
+
+## Default values
+
+The following snippets illustrate the default values that are inherited from the [default configuration](https://github.com/EclipseFdn/otterdog-defaults/blob/main/otterdog-defaults.libsonnet) 
+used at the Eclipse Foundation in a more human readable form.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,20 @@
+site_name: Otterdog configuration @ eclipse-velocitas
+site_description: Otterdog configuration @ eclipse-velocitas
+strict: true
+
+site_url: https://eclipse-velocitas.github.io/.eclipsefdn/
+
+docs_dir: ./docs
+site_dir: ./_site
+
+theme:
+  name: 'material'
+
+markdown_extensions:
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins: []
+nav: []
+watch: []

--- a/otterdog/eclipse-velocitas.jsonnet
+++ b/otterdog/eclipse-velocitas.jsonnet
@@ -348,11 +348,11 @@ orgs.newOrg('eclipse-velocitas') {
         },
       ],
     },
-    orgs.newRepo('velocitas-project-generator-npm') {
+    orgs.newRepo('velocitas-lib') {
       allow_merge_commit: false,
       allow_update_branch: false,
       delete_branch_on_merge: true,
-      description: "velocitas-project-generator-npm",
+      description: "A Python-based velocitas module which enables development of Velocitas CLI packages.",
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -364,11 +364,11 @@ orgs.newOrg('eclipse-velocitas') {
         },
       ],
     },
-    orgs.newRepo('velocitas-lib') {
+    orgs.newRepo('velocitas-project-generator-npm') {
       allow_merge_commit: false,
       allow_update_branch: false,
       delete_branch_on_merge: true,
-      description: "A Python-based velocitas module which enables development of Velocitas CLI packages.",
+      description: "velocitas-project-generator-npm",
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {

--- a/otterdog/eclipse-velocitas.jsonnet
+++ b/otterdog/eclipse-velocitas.jsonnet
@@ -325,6 +325,9 @@ orgs.newOrg('eclipse-velocitas') {
       allow_update_branch: false,
       delete_branch_on_merge: true,
       description: "Documentation artifacts of Velocitas",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "docs",
+      gh_pages_source_path: "/",
       homepage: "https://eclipse.dev/velocitas",
       web_commit_signoff_required: false,
       branch_protection_rules: [

--- a/otterdog/eclipse-velocitas.jsonnet
+++ b/otterdog/eclipse-velocitas.jsonnet
@@ -364,5 +364,21 @@ orgs.newOrg('eclipse-velocitas') {
         },
       ],
     },
+    orgs.newRepo('velocitas-lib') {
+      allow_merge_commit: false,
+      allow_update_branch: false,
+      delete_branch_on_merge: true,
+      description: "A Python-based velocitas module which enables development of Velocitas CLI packages.",
+      web_commit_signoff_required: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          dismisses_stale_reviews: true,
+          require_last_push_approval: true,
+          required_approving_review_count: 1,
+          requires_conversation_resolution: true,
+          requires_strict_status_checks: true,
+        },
+      ],
+    },
   ],
 }

--- a/otterdog/eclipse-velocitas.jsonnet
+++ b/otterdog/eclipse-velocitas.jsonnet
@@ -323,11 +323,11 @@ orgs.newOrg('eclipse-velocitas') {
       allow_merge_commit: false,
       allow_update_branch: false,
       delete_branch_on_merge: true,
-      has_discussions: true,
       description: "Documentation artifacts of Velocitas",
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "docs",
       gh_pages_source_path: "/",
+      has_discussions: true,
       homepage: "https://eclipse.dev/velocitas",
       web_commit_signoff_required: false,
       branch_protection_rules: [

--- a/otterdog/eclipse-velocitas.jsonnet
+++ b/otterdog/eclipse-velocitas.jsonnet
@@ -117,7 +117,6 @@ orgs.newOrg('eclipse-velocitas') {
       allow_merge_commit: false,
       allow_update_branch: false,
       delete_branch_on_merge: true,
-      has_discussions: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -324,6 +323,7 @@ orgs.newOrg('eclipse-velocitas') {
       allow_merge_commit: false,
       allow_update_branch: false,
       delete_branch_on_merge: true,
+      has_discussions: true,
       description: "Documentation artifacts of Velocitas",
       gh_pages_build_type: "legacy",
       gh_pages_source_branch: "docs",

--- a/otterdog/eclipse-velocitas.jsonnet
+++ b/otterdog/eclipse-velocitas.jsonnet
@@ -25,6 +25,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('.github') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -39,6 +40,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('cli') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -53,6 +55,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devcontainer-base-images') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       description: "devcontainer base images",
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -68,6 +71,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-devcontainer-setup') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -82,6 +86,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-github-integration') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -96,6 +101,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-github-templates') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -110,6 +116,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-github-workflows') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       has_discussions: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -125,6 +132,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-runtime-k3d') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -139,6 +147,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-runtime-local') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -153,6 +162,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-runtimes') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -199,6 +209,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-app-cpp-sdk') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       description: "vehicle-app-cpp-sdk",
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -214,6 +225,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-app-cpp-template') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       description: "vehicle-app-cpp-template",
       is_template: true,
       web_commit_signoff_required: false,
@@ -263,6 +275,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-model-cpp') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       description: "vehicle-model-cpp",
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -335,6 +348,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('velocitas-project-generator-npm') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      delete_branch_on_merge: true,
       description: "velocitas-project-generator-npm",
       web_commit_signoff_required: false,
       branch_protection_rules: [

--- a/otterdog/eclipse-velocitas.jsonnet
+++ b/otterdog/eclipse-velocitas.jsonnet
@@ -26,6 +26,7 @@ orgs.newOrg('eclipse-velocitas') {
       allow_merge_commit: false,
       allow_update_branch: false,
       delete_branch_on_merge: true,
+      has_wiki: false,
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
@@ -40,6 +41,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('cli') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -55,6 +57,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devcontainer-base-images') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "devcontainer base images",
       web_commit_signoff_required: false,
@@ -71,6 +74,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-devcontainer-setup') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -86,6 +90,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-github-integration') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -101,6 +106,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-github-templates') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -116,6 +122,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-github-workflows') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -131,6 +138,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-runtime-k3d') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -146,6 +154,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-runtime-local') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -161,6 +170,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('devenv-runtimes') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -176,6 +186,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('license-check') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "license-check",
       web_commit_signoff_required: false,
@@ -192,6 +203,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('release-documentation-action') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "release-documentation-action",
       web_commit_signoff_required: false,
@@ -208,6 +220,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-app-cpp-sdk') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "vehicle-app-cpp-sdk",
       web_commit_signoff_required: false,
@@ -224,6 +237,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-app-cpp-template') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "vehicle-app-cpp-template",
       is_template: true,
@@ -241,6 +255,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-app-python-sdk') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "vehicle-app-python-sdk",
       web_commit_signoff_required: false,
@@ -257,6 +272,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-app-python-template') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "vehicle-app-python-template",
       is_template: true,
@@ -274,6 +290,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-model-cpp') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "vehicle-model-cpp",
       web_commit_signoff_required: false,
@@ -290,6 +307,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-model-generator') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "vehicle-model-generator",
       web_commit_signoff_required: false,
@@ -306,6 +324,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('vehicle-model-python') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "vehicle-model-python",
       web_commit_signoff_required: false,
@@ -322,6 +341,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('velocitas-docs') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: true,
       delete_branch_on_merge: true,
       description: "Documentation artifacts of Velocitas",
       gh_pages_build_type: "legacy",
@@ -350,6 +370,7 @@ orgs.newOrg('eclipse-velocitas') {
     },
     orgs.newRepo('velocitas-lib') {
       allow_merge_commit: false,
+      has_wiki: false,
       allow_update_branch: false,
       delete_branch_on_merge: true,
       description: "A Python-based velocitas module which enables development of Velocitas CLI packages.",
@@ -367,6 +388,7 @@ orgs.newOrg('eclipse-velocitas') {
     orgs.newRepo('velocitas-project-generator-npm') {
       allow_merge_commit: false,
       allow_update_branch: false,
+      has_wiki: false,
       delete_branch_on_merge: true,
       description: "velocitas-project-generator-npm",
       web_commit_signoff_required: false,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material


### PR DESCRIPTION
As far as we document our Velocitas Project centralized in one place, to avoid maintenance effort, proposal is to disable wiki tab for other project but velocitas-docs to not confuse our user/customers.